### PR TITLE
"better" cli?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # lodestone-parser
 Parse lodestone for those juicy details
 
-- Run `php cli <func> <arg1> <arg2> <arg3>` for debugging
+- Run `php cli <func> <arguments>` for debugging
 - Run `php tests` to validate tests
+
+|CLI Command|Arguments|Description|
+|-|-|-|
+|`character`|`<id>`|Prints a character parse.
+|`freecompany`|`<id>`|Prints a freecompanies parse.|
+|`pvpteam`|`<id>`|Prints a pvpteam parse.|
+|`linkshell`|`<id>`|Prints a linkshell parse.|
+|`achievements`|`<id>`|Prints a characters achievement parse.|
+|`banners`|none|Prints the currently displayed banners on the lodestone homepage.|
+|`leaderboards`|`feast`,`potd`,`hoh`|Prints the current leaderboard parse for The Feast, Palace of The Dead, or Heaven on High.|
+
+All commands accept a flag to print the returned blob to a json file.
+Example
+```
+// prints returned object to file myCharacter.json
+php cli character <lodestoneid> -file myCharacter
+```

--- a/cli
+++ b/cli
@@ -11,4 +11,143 @@ require __DIR__ . '/vendor/autoload.php';
 
 $api = new \Lodestone\Api();
 
-print_r($api->character()->get('9575452')->Title);
+print_r($argv);
+
+if ($argc < 2) {
+    print("No arguments provided.\n");
+    return;
+}
+
+// Remove the cli file from the arguments array
+array_shift($argv);
+$cliCommandType = $argv[0];
+
+switch($cliCommandType) {
+    case "character":
+        if (!isset($argv[1])) {
+            print_r("INVALID ARGUMENT: Expected Character ID\n");
+            break;
+        }
+        print_r("Parsing character of {$argv[1]}...\n");
+        $results = $api->character()->get($argv[1]);
+        if (isset($argv[2]) == "-file") {
+            $file = fopen("{$argv[3]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+
+    case "freecompany":
+        if (!isset($argv[1])) {
+            print_r("INVALID ARGUMENT: Expected FreeCompany ID\n");
+            break;
+        }
+        print_r("Parsing freecompany of {$argv[1]}...\n");
+        $results = $api->freecompany()->get($argv[1]);
+        if (isset($argv[2]) == "-file") {
+            $file = fopen("{$argv[3]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+
+    case "pvpteam":
+        if (!isset($argv[1])) {
+            print_r("INVALID ARGUMENT: Expected PVP Team ID\n");
+            break;
+        }
+        print_r("Parsing pvp team of {$argv[1]}...\n");
+        $results = $api->pvpteam()->get($argv[1]);
+        if (isset($argv[2]) == "-file") {
+            $file = fopen("{$argv[3]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+
+    case "linkshell":
+        if (!isset($argv[1])) {
+            print_r("INVALID ARGUMENT: Expected Linkshell ID\n");
+            break;
+        }
+        print_r("Parsing linkshell of {$argv[1]}...\n");
+        $results = $api->linkshell()->get($argv[1])->Results;
+        if (isset($argv[2]) == "-file") {
+            $file = fopen("{$argv[3]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+
+    case "achievements":
+        if (!isset($argv[1])) {
+            print_r("INVALID ARGUMENT: Expected Linkshell ID\n");
+            break;
+        }
+        print_r("Parsing achievements of {$argv[1]}...\n");
+        $results = $api->character()->achievements($argv[1]);
+        if (isset($argv[2]) == "-file") {
+            $file = fopen("{$argv[3]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+
+    case "banners":
+        $results = $api->lodestone()->banners();
+        if (isset($argv[1]) == "-file") {
+            $file = fopen("{$argv[2]}.json", 'w');
+            fwrite($file, json_encode($results));
+            fclose($file);
+            break;
+        }
+        print_r($results);
+        break;
+        
+    case "leaderboards":
+        // Don't @me I know this is scuff.
+        switch ($argv[1]) {
+            case "feast":
+                $results = $api->leaderboards()->feast();
+                if (isset($argv[2]) == "-file") {
+                    $file = fopen("{$argv[3]}.json", 'w');
+                    fwrite($file, json_encode($results));
+                    fclose($file);
+                    break;
+                }
+                print_r($results);
+                break;
+
+            case "potd":
+                $results = $api->leaderboards()->ddPalaceOfTheDead();
+                if (isset($argv[2]) == "-file") {
+                    $file = fopen("{$argv[3]}.json", 'w');
+                    fwrite($file, json_encode($results));
+                    fclose($file);
+                    break;
+                }
+                print_r($results);
+                break;
+
+            case "hoh":
+                $results = $api->leaderboards()->ddHeavenOnHigh();
+                if (isset($argv[2]) == "-file") {
+                    $file = fopen("{$argv[3]}.json", 'w');
+                    fwrite($file, json_encode($results));
+                    fclose($file);
+                    break;
+                }
+                print_r($results);
+                break;
+        }
+}


### PR DESCRIPTION
I don't actually know how php works. I was just bored at work and I think the old cli was designed with the old methods in mind so I added a bunch of switch cases that let you do things to test things ya know?

This shouldn't actually affect any of the parser logic itself so I would like to think this would be zero impact on xivapi itself and will just be nice for us to use whenever we need to find if the issue is on xivapi side or parser side.