### PR TITLE
Remove debug output for Linkshell and Cross world linkshell parsers

### DIFF
--- a/src/Lodestone/Parser/ParseLinkshellCWMembers.php
+++ b/src/Lodestone/Parser/ParseLinkshellCWMembers.php
@@ -44,7 +44,7 @@ class ParseLinkshellCWMembers extends ParseAbstract implements Parser
 
 			$this->list->Results[] = $obj;
 		}
-		print_r($this->list);
+
 		return $this->list;
 	}
 }

--- a/src/Lodestone/Parser/ParseLinkshellMembers.php
+++ b/src/Lodestone/Parser/ParseLinkshellMembers.php
@@ -44,7 +44,7 @@ class ParseLinkshellMembers extends ParseAbstract implements Parser
 
             $this->list->Results[] = $obj;
         }
-        print_r($this->list);
+
         return $this->list;
     }
 }


### PR DESCRIPTION
https://github.com/xivapi/lodestone-parser/pull/18 added `print_r` calls, which are probably accidental. This PR removes those :sweat_smile: 