### PR TITLE
Add base PHPStan configuration

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -35,5 +35,8 @@ jobs:
               with:
                   dependency-versions: ${{ matrix.composer_preference }}
 
+            - name: Run PHPStan
+              run: composer run-script phpstan
+
             - name: Run test suite
               run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "rct567/dom-query": "^0.8.0"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^8|^9"
     },
     "autoload": {
@@ -35,6 +36,7 @@
         }
     },
     "scripts": {
+        "phpstan": "phpstan",
         "test": "phpunit"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,131 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_ireplace expects array\\|string, null given\\.$#"
+			count: 1
+			path: src/Lodestone/Api/DevPosts.php
+
+		-
+			message: "#^Cannot use array destructuring on bool\\|object\\.$#"
+			count: 1
+			path: src/Lodestone/Game/ClassJobs.php
+
+		-
+			message: "#^Method Lodestone\\\\Game\\\\ClassJobs\\:\\:findClassJob\\(\\) never returns object so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/Lodestone/Game/ClassJobs.php
+
+		-
+			message: "#^Method Lodestone\\\\Game\\\\ClassJobs\\:\\:findClassJob\\(\\) should return bool\\|object but returns array\\<int, int\\>\\.$#"
+			count: 1
+			path: src/Lodestone/Game/ClassJobs.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_ireplace expects array\\|string, null given\\.$#"
+			count: 1
+			path: src/Lodestone/Game/ClassJobs.php
+
+		-
+			message: "#^Static property Lodestone\\\\Http\\\\AsyncHandler\\:\\:\\$requestId \\(string\\) does not accept null\\.$#"
+			count: 1
+			path: src/Lodestone/Http/AsyncHandler.php
+
+		-
+			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 43$#"
+			count: 1
+			path: src/Lodestone/Http/Http.php
+
+		-
+			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 51$#"
+			count: 1
+			path: src/Lodestone/Http/Http.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 2
+			path: src/Lodestone/Parser/ParseCharacter.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_ireplace expects array\\|string, null given\\.$#"
+			count: 2
+			path: src/Lodestone/Parser/ParseCharacter.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseCharacterAchievements.php
+
+		-
+			message: "#^Call to function unset\\(\\) contains undefined variable \\$box\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseCharacterClassJobs.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_ireplace expects array\\|string, null given\\.$#"
+			count: 6
+			path: src/Lodestone/Parser/ParseCharacterClassJobs.php
+
+		-
+			message: "#^Variable \\$node in PHPDoc tag @var does not match assigned variable \\$bozjan\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseCharacterClassJobs.php
+
+		-
+			message: "#^Access to an undefined property Rct567\\\\DomQuery\\\\DomQuery\\:\\:\\$dom\\.$#"
+			count: 2
+			path: src/Lodestone/Parser/ParseFreeCompany.php
+
+		-
+			message: "#^Call to an undefined method Rct567\\\\DomQuery\\\\DomQuery\\:\\:getServerAndDc\\(\\)\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseFreeCompany.php
+
+		-
+			message: "#^Call to an undefined method Rct567\\\\DomQuery\\\\DomQuery\\:\\:getTimestamp\\(\\)\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseFreeCompany.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_ireplace expects array\\|string, null given\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseFreeCompany.php
+
+		-
+			message: "#^Access to an undefined property Lodestone\\\\Entity\\\\ListView\\\\ListView\\:\\:\\$Profile\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseLinkshellCWMembers.php
+
+		-
+			message: "#^Access to an undefined property Lodestone\\\\Entity\\\\ListView\\\\ListView\\:\\:\\$Profile\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseLinkshellMembers.php
+
+		-
+			message: "#^Variable \\$node in PHPDoc tag @var does not match assigned variable \\$arr\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseLodestoneBanners.php
+
+		-
+			message: "#^Variable \\$node in PHPDoc tag @var does not match assigned variable \\$arr\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParseLodestoneWorldStatus.php
+
+		-
+			message: "#^Access to an undefined property Lodestone\\\\Entity\\\\ListView\\\\ListView\\:\\:\\$Profile\\.$#"
+			count: 1
+			path: src/Lodestone/Parser/ParsePvPTeamMembers.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Lodestone\\\\Api\\\\Character\\:\\:following\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Lodestone\\\\Api\\\\Character\\:\\:friends\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Lodestone\\\\Api\\\\Character\\:\\:get\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests

--- a/src/Lodestone/Api.php
+++ b/src/Lodestone/Api.php
@@ -20,6 +20,12 @@ class Api
     private $namespaces = [];
 
     /**
+     * @template T
+     *
+     * @param class-string<T> $namespace
+     *
+     * @return T
+     *
      * will return an existing set namespace or a new one.
      */
     private function getApiNamespace($namespace)


### PR DESCRIPTION
This PR adds [PHPStan static analysis library](https://phpstan.org/user-guide/getting-started) + Github workflow to launch those tests automatically.

Selected ruleset level is 5, which is the recommended value for catching all basic PHP code issues. You can see the rulesets here: https://phpstan.org/user-guide/rule-levels.

> 1. basic checks, unknown classes, unknown functions, unknown methods called on $this, wrong number of arguments passed to those methods and functions, always undefined variables
> 2. possibly undefined variables, unknown magic methods and properties on classes with __call and __get
> 3. unknown methods checked on all expressions (not just $this), validating PHPDocs
> 4. return types, types assigned to properties
> 5. basic dead code checking - always false instanceof and other type checks, dead else branches, unreachable code after return; etc.
> 6. checking types of arguments passed to methods and functions
> 7. report missing typehints
> 8. report partially wrong union types - if you call a method that only exists on some types in a union type, level 7 starts to report that; other possibly incorrect situations
> 9. report calling methods and accessing properties on nullable types
> 10. be strict about the mixed type - the only allowed operation you can do with it is to pass it to another mixed

All existing issues are put into "baseline", except me changing the PHPDoc for the `Api` factory methods.

A higher ruleset is available as needed (and usually recommended level is 7-8).

See:
 * https://github.com/Steveb-p/lodestone-parser/pull/1
for test results.