### PR TITLE
Add PHP 8

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -18,6 +18,10 @@ jobs:
                 php:
                     - '7.2'
                     - '7.4'
+                    - '8.0'
+                    - '8.1'
+                    - '8.2'
+                    - '8.3'
                 composer_preference:
                     - 'lowest'
                     - 'highest'
@@ -32,6 +36,13 @@ jobs:
                   coverage: none
 
             - uses: ramsey/composer-install@v2
+              if: ${{ fromJSON(matrix.php) >= 8 }}
+              with:
+                  dependency-versions: ${{ matrix.composer_preference }}
+                  composer-options: '--with phpunit/phpunit:^9 --with symfony/http-client:^5.2'
+
+            - uses: ramsey/composer-install@v2
+              if: ${{ fromJSON(matrix.php) < 8 }}
               with:
                   dependency-versions: ${{ matrix.composer_preference }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8",
         "symfony/css-selector": ">=3.2",
         "nesbot/carbon": "^2.10",
         "symfony/http-client": "^4.3|^5.0",
         "ramsey/uuid": "^3.8|^4.0",
-        "rct567/dom-query": "^0.8.0"
+        "rct567/dom-query": "^0.8|^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9"


### PR DESCRIPTION
This PR adds support for PHP version 8.

> [!WARNING]
> Require `phpunit/phpunit:^9` and `symfony/http-client:^5.2` for PHP 8.
>
> A note in readme.md might be considered.