### PR TITLE
Remove unused Carbon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.2",
         "symfony/css-selector": ">=3.2",
-        "nesbot/carbon": "^2.10",
         "symfony/http-client": "^4.3|^5.0",
         "ramsey/uuid": "^3.8|^4.0",
         "rct567/dom-query": "^0.8.0"


### PR DESCRIPTION
Carbon dependency is not used in this library and could be removed from dependencies.

Carbon is currently incompatible with Symfony 7.